### PR TITLE
fix: stop theme, sound and haptic shortcuts from firing while typing

### DIFF
--- a/hooks/use-haptic-toggle.ts
+++ b/hooks/use-haptic-toggle.ts
@@ -39,8 +39,6 @@ export const useHapticsToggle = () => {
     "h",
     () => toggleHaptics(),
     {
-      enableOnContentEditable: true,
-      enableOnFormTags: true,
       preventDefault: true,
     },
     [toggleHaptics]

--- a/hooks/use-sound-toggle.ts
+++ b/hooks/use-sound-toggle.ts
@@ -29,8 +29,6 @@ export const useSoundToggle = () => {
     "s",
     () => toggleSound(),
     {
-      enableOnContentEditable: true,
-      enableOnFormTags: true,
       preventDefault: true,
     },
     [toggleSound]

--- a/hooks/use-theme-toggle.ts
+++ b/hooks/use-theme-toggle.ts
@@ -33,8 +33,6 @@ export const useThemeToggle = () => {
     "d",
     () => toggleTheme(),
     {
-      enableOnContentEditable: true,
-      enableOnFormTags: true,
       preventDefault: true,
     },
     [toggleTheme]


### PR DESCRIPTION
Refs #7

## Problem

`d`, `s` and `h` cannot be typed anywhere on the site. Each one triggers a global shortcut instead of entering a character, and the keystroke never reaches the field. `d` toggles the theme, `s` toggles sound, `h` toggles haptics.

The OG image preview is the worst place to hit this, since customizing a card means typing real prose into the inputs. A title like "How we generate social images at the edge" loses every `d`, `s` and `h`.

## Reproducing on main

1. Open a component page, for example `/docs/components/content/blog`.
2. Click into the Title field under "Customize".
3. Press `d`, then `s`, then `h`.
4. No characters appear. The theme flips, sound toggles, haptics toggle.
5. Press any other letter, for example `x`. It is inserted normally.

The Cmd+K search behaves the same way. Typing `docs` leaves `oc` in the box.

## Cause

`hooks/use-theme-toggle.ts`, `hooks/use-sound-toggle.ts` and `hooks/use-haptic-toggle.ts` each bind a bare letter with `useHotkeys` and pass `enableOnFormTags: true` and `enableOnContentEditable: true`. Those two options are what let the shortcut run while someone is typing. `preventDefault: true` then cancels the keystroke, which is why the character disappears instead of arriving alongside the toggle.

react-hotkeys-hook disables hotkeys on form tags and on contenteditable elements by default, so those two options are the only thing standing between the current behaviour and the correct one.

## What changed

Removed `enableOnFormTags` and `enableOnContentEditable` from the three hooks. Six deleted lines, nothing else.

`preventDefault: true` stays. In react-hotkeys-hook 5.2.4 it is applied downstream of both guards, so once the two options are gone it cannot be reached while focus is in a field, and it still does its job when focus is outside one.

This also brings the three hooks in line with the single-key shortcuts already registered elsewhere in this repository. `components/download-button.tsx` binds `s` and `components/component-preview.tsx` binds `r`, both with `preventDefault: true` and neither with the two `enableOn*` options.

For corroboration outside this repository, shadcn/ui guards the same `d` theme shortcut in `apps/v4/components/mode-switcher.tsx`. It returns early when the event target is an `HTMLInputElement`, `HTMLTextAreaElement`, `HTMLSelectElement` or is contenteditable, and calls `preventDefault()` only after those checks pass.

## Verification

Checked in the browser against the dev server.

In a preview text input and in the Cmd+K search, `d`, `s` and `h` now type as characters and no shortcut fires. Typing `docs` into the search now gives `docs`. The same holds in a contenteditable element.

With focus outside any field, all three shortcuts still work. `d` toggles the theme, `s` toggles sound, `h` toggles haptics, and Cmd+K still opens the search.

`pnpm check`, `pnpm typecheck` and `pnpm build` all pass.

## Not in this pull request

Holding one of these keys still re-toggles for as long as the key is down, because nothing guards `event.repeat`. That behaviour exists in shadcn/ui's implementation too, so it is a change in behaviour rather than a fix for a deviation, and it is your call whether you want it. It is described in #7 and deliberately left out here. This pull request therefore references #7 rather than closing it, and #7 should stay open until you have decided on the repeat behaviour.
